### PR TITLE
fix: ensure swipe component stays below when a modal is open

### DIFF
--- a/web/src/components/SwiperStyled.tsx
+++ b/web/src/components/SwiperStyled.tsx
@@ -20,6 +20,7 @@ const SwiperStyled = ({ children }: { children: ReactNode }) => {
                     '--swiper-navigation-size': '1.75rem',
                     '--swiper-navigation-color': '#00ADB5',
                     '--swiper-pagination-color': '#00ADB5',
+                    zIndex: 0,
                 } as React.CSSProperties
             }
         >


### PR DESCRIPTION
## Pull Request Title  
fix: ensure swipe component stays below when a modal is open  

---

## Description  
Add zIndex property in swiper component 

### Changes Include  
- [ ] Feature implementation  
- [x] Bug fix  
- [ ] Refactor  
- [ ] Documentation update  
- [ ] Other (please specify):  

### What is the current behavior?  
The images is shown above the modals

### What is the new behavior?  
The images is show below the modals

---

## Checklist  
- [x] My code follows the project's coding standards  
- [ ] I have added tests to cover my changes  
- [x] I have updated documentation if necessary  
- [x] No new warnings or errors were introduced  
